### PR TITLE
Detect API throttling (Enhance Your Calm) to retry

### DIFF
--- a/ello-gen.sh
+++ b/ello-gen.sh
@@ -5,8 +5,17 @@ for i in $(cat words.txt); do
         for k in $(cat words.txt); do
             content="$(curl -s "$url/$i-$j-$k)")"
             torf="${content:13:1}"
+
+            while [ "$content" == "Enhance your calm" ]; do
+                echo "    > Waiting 10s and trying again..."
+                sleep 10
+
+                content="$(curl -s "$url/$i-$j-$k)")"
+                torf="${content:13:1}"
+            done
+
             if [ $torf == "t" ]; then
-                echo $i-$j-$k
+                echo "$i-$j-$k"
             fi
         done
     done


### PR DESCRIPTION
Currently the script just barrels through a bunch of codes to check for a true/false return without checking if we're being flagged for abuse. Every time Enhance Your Calm is encountered, wait 10s and try again; eventually Ello just allows another cluster of API calls for us, but the time needed to wait appears to increase with each EYC.
